### PR TITLE
Set update interval to 10s

### DIFF
--- a/markettips.js
+++ b/markettips.js
@@ -100,4 +100,4 @@ MT.init = function() {
 MT.init();
 
 
-setInterval(MT.tick, 60*1000);
+setInterval(MT.tick, 10*1000);


### PR DESCRIPTION
If player loads the mod when there're just 5 seconds left till the next market tick, he have to wait for that last 5 seconds for the mod to update and spend other 55 seconds with outdated values. To fix it, we can change update interval to 10 seconds.